### PR TITLE
Prevent wok swings if player has item

### DIFF
--- a/core/src/edu/cornell/gdiac/nightbite/WorldController.java
+++ b/core/src/edu/cornell/gdiac/nightbite/WorldController.java
@@ -626,7 +626,9 @@ public class WorldController implements Screen, InputProcessor {
     public boolean touchDown(int screenX, int screenY, int pointer, int button) {
         float clickX = screenX * worldModel.getWidth() / screenWidth;
         float clickY = worldModel.getHeight() - (screenY * worldModel.getHeight() / screenHeight);
-        worldModel.getPlayers().get(0).swingWok(new Vector2(clickX, clickY), worldModel.getFirecrackers(), worldModel.getEnemies());
+        // Swing wok only if player doesn't have an item
+        PlayerModel player = worldModel.getPlayers().get(0);
+        if (!player.hasItem()) player.swingWok(new Vector2(clickX, clickY), worldModel.getFirecrackers(), worldModel.getEnemies());
         return true;
     }
 


### PR DESCRIPTION
Previously, players were allowed to swing woks and reflect other objects even when holding an item. This prevents players from swinging woks when holding an item.

Note: If previous behavior was intended, just close this PR!